### PR TITLE
Fixing travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,9 @@ jobs:
       script: python convert.py
     - name: check notebooks
       script: python -m "nbpages.check_nbs" --commit-range="${TRAVIS_COMMIT_RANGE/.../..}"  # see https://github.com/travis-ci/travis-ci/issues/4596 for why this bit in TRAVIS_COMMIT_RANGE is necessary
-    - stage: deploy
-      if: type != "pull_request" AND branch = "master"
-      script: python convert.py
-      deploy:
-        provider: pages
-        skip-cleanup: true
-        github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
-        keep-history: true
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
     - pip install git+https://github.com/eteq/nbpages.git#egg=nbpages
+    - pip install ci-watson

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 
 jobs:
   include:
-    - name: run/convert notebooks
-      script: python convert.py
     - name: check notebooks
       script: python -m "nbpages.check_nbs" --commit-range="${TRAVIS_COMMIT_RANGE/.../..}"  # see https://github.com/travis-ci/travis-ci/issues/4596 for why this bit in TRAVIS_COMMIT_RANGE is necessary
 


### PR DESCRIPTION
Removing deploy stage in travis builds. Travis will serve as first wave of testing when users are contributing PRs because of the useful interfacing with Github. The Deployment stage will be handled by Jenkins nightly in the future.