### PR TITLE
Changed miricoords and miri3d to install as editable

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -49,4 +49,5 @@ jobs:
     - name: Test with nbpages
       shell: bash -l {0}
       run: |
+        cd jwst_validation_notebooks
         python -m "nbpages.check_nbs"

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,10 @@ distribute-*.tar.gz
 *.html
 exec*.ipynb
 
+# Directory produced for packages that need to be installed with pip -e to have their
+#   data files show up
+src
+
 # Compiled source #
 ###################
 *.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   include:
     - name: check notebooks
-      script: python -m "nbpages.check_nbs" --commit-range="${TRAVIS_COMMIT_RANGE/.../..}"  # see https://github.com/travis-ci/travis-ci/issues/4596 for why this bit in TRAVIS_COMMIT_RANGE is necessary
+      script: cd jwst_validation_notebooks; python -m "nbpages.check_nbs" --commit-range="${TRAVIS_COMMIT_RANGE/.../..}"  # see https://github.com/travis-ci/travis-ci/issues/4596 for why this bit in TRAVIS_COMMIT_RANGE is necessary
 
 install:
     # Now trying to do this with miniconda directly instead of via ci-helpers

--- a/environment.yml
+++ b/environment.yml
@@ -61,8 +61,8 @@ dependencies:
     - pytest-xdist
     - pytest-html
     # These repositories have no tags or releases yet, so none are chosen.
-    - git+https://github.com/STScI-MIRI/miricoord
-    - git+https://github.com/STScI-MIRI/miri3d
+    - -e git+https://github.com/STScI-MIRI/miricoord#egg=miricoord
+    - -e git+https://github.com/STScI-MIRI/miri3d#egg=miri3d
     - git+https://github.com/york-stsci/nbpages
     # This repository has tags, but selecting them doesn't seem to work.
     - git+https://github.com/spacetelescope/pysiaf

--- a/environment.yml
+++ b/environment.yml
@@ -61,8 +61,10 @@ dependencies:
     - pytest-xdist
     - pytest-html
     # These repositories have no tags or releases yet, so none are chosen.
-    - -e git+https://github.com/STScI-MIRI/miricoord#egg=miricoord
-    - -e git+https://github.com/STScI-MIRI/miri3d#egg=miri3d
+#    - -e git+https://github.com/STScI-MIRI/miricoord#egg=miricoord
+#    - -e git+https://github.com/STScI-MIRI/miri3d#egg=miri3d
+    - git+https://github.com/STScI-MIRI/miricoord
+    - git+https://github.com/STScI-MIRI/miri3d
     - git+https://github.com/york-stsci/nbpages
     # This repository has tags, but selecting them doesn't seem to work.
     - git+https://github.com/spacetelescope/pysiaf


### PR DESCRIPTION
This is currently needed to ensure that their data files are present, and in the expected place. In addition, in order to get this change to work, I had to change the .gitignore file to ignore the `src` directory that's created when creating the environment. And, finally, I had to change the test script to move into the jwst_validation_notebooks directory before running, since otherwise it tries to check the notebooks in the miri3d and miricoords modules, and those notebooks don't pass since they contain cells with output.