### PR TITLE
fixed typos

### DIFF
--- a/jwst_validation_notebooks/regression_test/resample/jwst_resample_unit_tests.ipynb
+++ b/jwst_validation_notebooks/regression_test/resample/jwst_resample_unit_tests.ipynb
@@ -191,7 +191,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "report"
+    "HTML(html_report)"
    ]
   },
   {

--- a/jwst_validation_notebooks/regression_test/skymatch/jwst_skymatch_unit_tests.ipynb
+++ b/jwst_validation_notebooks/regression_test/skymatch/jwst_skymatch_unit_tests.ipynb
@@ -181,7 +181,6 @@
     "with tempfile.TemporaryDirectory() as tmpdir:\n",
     "    outdir = os.path.join(tmpdir, 'regtest_report.html')\n",
     "    !pytest {skymatch} -v --ignore={associations} --ignore={datamodels} --ignore={stpipe} --ignore={regtest} --html={outdir} --self-contained-html\n",
-    "    report = display_report('tmpdir/unit_report.html')\n",
     "    with open(os.path.join(tmpdir, \"regtest_report.html\")) as report_file:\n",
     "        html_report = \"\".join(report_file.readlines())"
    ]


### PR DESCRIPTION
Fixed typos in two of the regression test notebooks.

- resample notebook was calling 'report' instead of 'HTML(html_report)'
- skymatch notebook hadn't removed the display_report() call but had removed the function