### PR TITLE
Add coron3 pipeline validation notebook for nircam

### DIFF
--- a/jwst_validation_notebooks/calwebb_coron3/jwst_calcoron3_nircam_test.ipynb
+++ b/jwst_validation_notebooks/calwebb_coron3/jwst_calcoron3_nircam_test.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"title_ID\"></a>\n",
+    "# JWST Pipeline Validation Notebook: \n",
+    "# calwebb_coron3\n",
+    "\n",
+    "<span style=\"color:red\"> **Instruments Affected**</span>: MIRI, NIRCam \n",
+    "\n",
+    "### Table of Contents\n",
+    "\n",
+    "<div style=\"text-align: left\"> \n",
+    "    \n",
+    "<br> [Introduction\\*](#intro)\n",
+    "<br> [JWST CalWG Algorithm\\*](#algorithm)\n",
+    "<br> [Test Description\\*](#description)\n",
+    "<br> [Data Description\\*](#data_descr)\n",
+    "<br> [Imports\\*](#imports)\n",
+    "<br> [Set up Temporary Directory\\*](#temp)\n",
+    "<br> [Loading the Data\\*](#data_load)\n",
+    "<br> [Run the Pipeline](#pipeline)\n",
+    "<br> [Perform Tests or Visualization](#testing) \n",
+    "<br> [About This Notebook\\*](#about)\n",
+    "<br>    \n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"intro\"></a>\n",
+    "# Introduction\n",
+    "\n",
+    "This notebook validates the stage 3 coronagraphic pipeline (calwebb_coron3).\n",
+    "\n",
+    "Step description: https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_coron3.html\n",
+    "\n",
+    "Pipeline code: https://github.com/spacetelescope/jwst/tree/master/jwst/coron\n",
+    "\n",
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"algorithm\"></a>\n",
+    "# JWST CalWG Algorithm\n",
+    "\n",
+    "The coron3 pipeline consists of the following steps:\n",
+    "\n",
+    "1) outlier_detection: identifies bad pixels/outliers in the input images\n",
+    "\n",
+    "2) stack_refs: stacks the reference PSFs together into a 3D data cube\n",
+    "\n",
+    "3) align_refs: aligns/shifts the stack of reference PSFs to the target PSFs\n",
+    "\n",
+    "4) klip: uses the Karhunen-Loeve Image Plane (KLIP) algorithm to fit and subtract an optimal PSF from the target PSFs\n",
+    "\n",
+    "5) resample: combines the PSF-subtracted target images into a single product\n",
+    "\n",
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"description\"></a>\n",
+    "# Test Description\n",
+    "\n",
+    "All steps of the calwebb_coron3 pipeline are run on the simulated input data.\n",
+    "\n",
+    "The tests will ensure basic header/data info in the output images is as expected (e.g. image dimensions, number of outliers detected), as well as inspect the quality of the PSF alignments and the PSF-subtracted images.\n",
+    "\n",
+    "\n",
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"data_descr\"></a>\n",
+    "# Data Description\n",
+    "\n",
+    "The NIRCam test data consists of 9 small-grid dithered reference PSFs (2 ints, 10 groups) as well as 1 target PSF (10 ints, 10 groups) with 2 companions. The instrument setup for these exposures is as follows:\n",
+    "\n",
+    "DETECTOR = NRCA2\n",
+    "\n",
+    "SUBARRAY = SUB640A210R\n",
+    "\n",
+    "FILTER = F210M\n",
+    "\n",
+    "PUPIL = MASKRND\n",
+    "\n",
+    "CORONMSK = MASKA210R\n",
+    "\n",
+    "READPATT = RAPID\n",
+    "\n",
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"imports\"></a>\n",
+    "# Imports\n",
+    "\n",
+    "* astropy.io for opening fits files\n",
+    "* ci_watson.artifactory_helpers to retrieve test data from artifactory\n",
+    "* glob for making file lists\n",
+    "* jwst.pipeline.calwebb_coron3 is the pipeline step being tested\n",
+    "* matplotlib.pyplot to generate plots\n",
+    "* os for file handling\n",
+    "* tempfile to create a temporary processing directory\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.io import fits\n",
+    "from ci_watson.artifactory_helpers import get_bigdata\n",
+    "import glob\n",
+    "from jwst.pipeline.calwebb_coron3 import Coron3Pipeline\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "import os\n",
+    "from tempfile import TemporaryDirectory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"temp\"></a>\n",
+    "# Set up Temporary Directory\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a temporary directory to hold notebook output, and change the working directory to that directory\n",
+    "\n",
+    "data_dir = TemporaryDirectory()\n",
+    "os.chdir(data_dir.name)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"data_load\"></a>\n",
+    "# Loading the Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copy the test files from Artifactory into the temporary directory\n",
+    "\n",
+    "files = ['lib_ss20_sgd1_calints.fits', 'lib_ss20_sgd2_calints.fits', 'lib_ss20_sgd3_calints.fits',\n",
+    "         'lib_ss20_sgd4_calints.fits', 'lib_ss20_sgd5_calints.fits', 'lib_ss20_sgd6_calints.fits',\n",
+    "         'lib_ss20_sgd7_calints.fits', 'lib_ss20_sgd8_calints.fits', 'lib_ss20_sgd9_calints.fits',\n",
+    "         'lib_ss20_target_roll1_calints.fits', 'coro_test.asn']\n",
+    "for f in files:\n",
+    "    file = get_bigdata('jwst_validation_notebooks',\n",
+    "                       'validation_data',\n",
+    "                       'calwebb_coron3',\n",
+    "                       'coron3_nircam_test', f)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"pipeline\"></a>\n",
+    "# Run the Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the coron3 pipeline\n",
+    "m = Coron3Pipeline()\n",
+    "m.save_results = True\n",
+    "\n",
+    "# Run the pipeline\n",
+    "m.run('coro_test.asn')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"testing\"></a>\n",
+    "# Perform Tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the PSF stack/alignment/subtraction images have the expected data dimensions.\n",
+    "# The expected dimensions for the psf stack images are:\n",
+    "# NX x NY x Number of Reference PSF INTS\n",
+    "# The expected dimensions for the psf alignment images are:\n",
+    "# NX x NY x Number of Reference PSF INTS x Number of Target INTS\n",
+    "# The expected dimensions for the psf subtraction images are:\n",
+    "# NX x NY x Number of Target INTS\n",
+    "\n",
+    "f_stack = 'coro_test_psfstack.fits'\n",
+    "f_align = 'lib_ss20_target_roll1_c1001_psfalign.fits'\n",
+    "f_sub = 'lib_ss20_target_roll1_c1001_psfsub.fits'\n",
+    "files = [f_stack, f_align, f_sub]\n",
+    "expected_shapes = [(18, 640, 640), (10, 18, 640, 640), (10, 640, 640)]\n",
+    "for f,shape in zip(files, expected_shapes):\n",
+    "    for ext in ['SCI', 'ERR', 'DQ']:\n",
+    "        data = fits.getdata(f, ext)\n",
+    "        if data.shape != shape:\n",
+    "            print('WARNING: unexpected data shape in {} {}: {}'.format(f, ext, data.shape))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure a reasonable number of outlier pixels are flagged in each exposure (less than 1%)\n",
+    "\n",
+    "files = sorted(glob.glob('*crfints.fits'))\n",
+    "for f in files:\n",
+    "    print(os.path.basename(f))\n",
+    "    dq = fits.getdata(f, 'DQ')\n",
+    "    nints, ny, nx = dq.shape\n",
+    "    for integration in range(nints):\n",
+    "        dq_int = dq[integration]\n",
+    "        n_outlier = len(dq_int[dq_int&16!=0])\n",
+    "        print('\\tOutlier pixels in Int {}: {} ({:.5f}% of image)'.format(integration+1,\n",
+    "              n_outlier, n_outlier/(ny*nx)*100))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the PSFs were aligned properly (i.e. residual alignment RMS should be <0.5 MJr/sr). \n",
+    "# Each frame represents one PSF-aligned reference integration. There shouldn't be any severe \"ringing\" \n",
+    "# effect from outlier pixels (i.e. cross pattern), as these should have been corrected in earlier steps.\n",
+    "# There also shouldn't be any PSF pattern offsets visible in the images, only salt/pepper noise.\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 9, figsize=(30,6))\n",
+    "y1, y2, x1, x2 = (269, 370, 269, 370)  # a cutout region around the PSF\n",
+    "\n",
+    "data = fits.getdata(f_align, 'SCI')\n",
+    "mean = np.mean(data[0], axis=0)\n",
+    "for i, ax in enumerate(axes.flatten()):\n",
+    "    diff = data[0, i] - mean\n",
+    "    diff = diff[y1:y2, x1:x2]\n",
+    "    r = np.sqrt(np.mean(diff**2))\n",
+    "    im = ax.imshow(diff, cmap='coolwarm', vmin=-1, vmax=1, origin='lower')\n",
+    "    ax.set_yticks([])\n",
+    "    ax.set_xticks([])\n",
+    "    ax.set_title('RMS={:.3f}'.format(r),size=15)\n",
+    "\n",
+    "fig.subplots_adjust(right=0.8)\n",
+    "cbar_ax = fig.add_axes([0.82, 0.15, 0.02, 0.7])\n",
+    "cbar = fig.colorbar(im, cax=cbar_ax)\n",
+    "cbar.ax.tick_params(labelsize=20) \n",
+    "cbar.ax.set_ylabel('PSF - Mean PSF [MJy/sr]', size=20)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the PSF fitting/subtraction worked properly. The 2 companions should be obviously visible\n",
+    "# in red in the top right/bottom left of the image, and the remainder of the image should be ~gray \n",
+    "# (i.e. residual RMS should be <0.5 MJy/sr).\n",
+    "\n",
+    "fig, axes = plt.subplots(1,10, figsize=(32, 6))\n",
+    "y1, y2, x1, x2 = (269, 370, 269, 370)  # a cutout region around the PSF\n",
+    "\n",
+    "data = fits.getdata(f_sub, 'SCI')\n",
+    "rms = []\n",
+    "for i, ax in enumerate(axes):\n",
+    "    d = data[i, y1:y2, x1:x2]\n",
+    "    r = np.sqrt(np.mean(d**2))\n",
+    "    im = ax.imshow(d, cmap='coolwarm', vmin=-1, vmax=1, origin='lower')\n",
+    "    ax.set_title('Sci Int {}'.format(i+1), size=20)\n",
+    "    ax.set_yticks([])\n",
+    "    ax.set_xticks([])\n",
+    "    rms.append(r)\n",
+    "    ax.text(70, 85, '{:.2f}'.format(r), size=15)\n",
+    "axes[0].set_ylabel('Mean RMS\\n={:.2f}'.format(np.mean(rms)), size=20, rotation='horizontal', labelpad=75)\n",
+    "\n",
+    "fig.subplots_adjust(right=0.8)\n",
+    "cbar_ax = fig.add_axes([0.82, 0.15, 0.02, 0.7])\n",
+    "cbar = fig.colorbar(im, cax=cbar_ax)\n",
+    "cbar.ax.tick_params(labelsize=20) \n",
+    "cbar.ax.set_ylabel('Residual PSF [MJy/sr]', size=20)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the final, combined PSF-subtracted image looks good as well (should just look like \n",
+    "# a cleaner combination of the above, with residual RMS <0.15)\n",
+    "\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "data = fits.getdata('coro_test_i2d.fits', 'SCI')\n",
+    "data = data[300:450, 300:450]\n",
+    "plt.imshow(data, cmap='coolwarm', vmin=-1, vmax=1, origin='lower')\n",
+    "plt.colorbar(label='Residual PSF [MJy/sr]')\n",
+    "rms = np.sqrt(np.mean(data**2))\n",
+    "plt.title('Residual RMS={:.3f}'.format(rms))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"about\"></a>\n",
+    "## About this Notebook\n",
+    "**Author:** Ben Sunnquist, Staff Scientist, NIRCam\n",
+    "<br>**Updated On:** 02/10/2021"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)\n",
+    "<img style=\"float: right;\" src=\"./stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"stsci_pri_combo_mark_horizonal_white_bkgd\" width=\"200px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This PR adds a validation notebook for the calwebb_coron3 pipeline for NIRCam. 

It checks the following, using a simulation set of 9 small-grid dithered reference PSFs and 1 target PSF with 2 companions:
- SCI/ERR/DQ data dimensions are as expected in the psf stack/alignment/subtraction outputs
- a reasonable number of outliers are flagged in the outlier_detection step
- the PSF alignments and fitting/subtraction steps worked properly and have reasonable RMS values

The simulation data has already been ingested into Artifactory by Misty, and I was able to access it successfully in this notebook.