### PR TITLE
Update convert.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Make sure to follow the template outlined in
 [our repository](https://github.com/spacetelescope/jwst_validation_notebooks/blob/master/jwst_validation_notebooks/templates/jwst_validation_notebook_template.ipynb).
 More information about storing test data is included below.
 
+Before your notebook will be accepted, you must test it in the proper environment 
+described in the [Executing Validation Notebooks Locally](https://github.com/spacetelescope/jwst_validation_notebooks#executing-validation-notebooks-locally)
+section above. This will help ensure a smoother delivery of new tests. 
+
 This repository operates using the standard
 [fork and pull request github](https://gist.github.com/Chaser324/ce0505fbed06b947d962)
 workflow. The following is a bare bones example of this work flow for contributing to the

--- a/convert.py
+++ b/convert.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
-import os
 import logging
+import os
+import platform
+import resource
+
+if platform.system() == 'Darwin':
+    # Raise the rather small default 256-open-files-only limit to 1024
+    no_files = 1024
+    resource.setrlimit(resource.RLIMIT_NOFILE, (no_files, no_files))
 
 from nbpages import make_parser, run_parsed, make_html_index
 


### PR DESCRIPTION
On macOS, add code to increase the number-of-open-files resource limit from 250 to 1024. This should stop or reduce errors related to too many open files on macOS.