### PR TITLE
Remove python 3.6 from test grid

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,10 +18,6 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.6
-            os: ubuntu-latest
-            python: 3.6
-
           - name: Python 3.7
             os: ubuntu-latest
             python: 3.7


### PR DESCRIPTION
Assorted test packages are no longer compatible with python 3.6