### PR TITLE
Added non-crashing assertion test function to template

### DIFF
--- a/jwst_validation_notebooks/templates/jwst_validation_notebook_template.ipynb
+++ b/jwst_validation_notebooks/templates/jwst_validation_notebook_template.ipynb
@@ -396,6 +396,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Assertion Test Function\n",
+    "\n",
+    "Using `assert()` statements to test code can be very important, but the problem with assertions is that a failed assertion will raise an exception and halt the notebook (and sometimes you want later tests to execute even if an earlier test failed, especially when the tests are independent of each other). In order to use assertions, but not halt the notebook on failure, this function wraps the assertion in a try/except block. As such, if the test fails, it will print out an error message but not stop later tests from running.\n",
+    "\n",
+    "This function is designed to be used when you\n",
+    "\n",
+    "* want to do an assertion test\n",
+    "* don't want a failed test to crash the rest of the notebook\n",
+    "* don't want to manually wrap the assertion in a try/except block\n",
+    "\n",
+    "It's intended to be called as:\n",
+    "\n",
+    "    test_assertion(test_condition, success_message, failure_message)\n",
+    "\n",
+    "where\n",
+    "\n",
+    "* test_condition is something that evaluates to either True or False. For example, \"np.max(detector_data)>0\", \n",
+    "  \"np.all(test_flags)\", \"header['some_header_keyword'] is not 'FAILED'\"\n",
+    "* success_message is an optional message to print out if the test succeeds. For example, \n",
+    "  \"Non-zero Data Test Passed\"\n",
+    "* failue_message is an optional (but *strongly* recommended) message to print out if the test fails. For example,\n",
+    "  \"ERROR: Non-zero Data Test FAILED\". If this is not provided, then the function will still print out a failure \n",
+    "  message, but it probably won't be very useful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_assertion(test_condition, success_message=None, failure_message=None):\n",
+    "    try:\n",
+    "        assert(test_condition)\n",
+    "        if success_message is not None:\n",
+    "            print(success_message)\n",
+    "    except AssertionError as e:\n",
+    "        if failure_message is not None:\n",
+    "            print(failure_message)\n",
+    "        else:\n",
+    "            print(\"Assertion {} failed.\".format(test_condition))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a id=\"testing\"></a>\n",
     "# Perform Tests or Visualization\n",
     "\n",


### PR DESCRIPTION
This adds a function that lets notebook writers use assertions in a relatively simple way without crashing the notebook on the first failure.