### PR TITLE
Fixing column names in source_catalog notebook

### DIFF
--- a/jwst_validation_notebooks/source_catalog/jwst_source_catalog_miri_test/jwst_source_catalog_miri_test.ipynb
+++ b/jwst_validation_notebooks/source_catalog/jwst_source_catalog_miri_test/jwst_source_catalog_miri_test.ipynb
@@ -358,7 +358,9 @@
    "outputs": [],
    "source": [
     "data = table.Table.read(photfile, format='ascii', comment='#')\n",
-    "print(data)"
+    "\n",
+    "smalltable = data['label', 'xcentroid', 'ycentroid','aper30_flux', 'aper50_flux', 'aper70_flux', 'CI_50_30', 'CI_70_50']\n",
+    "smalltable.pprint_all()"
    ]
   },
   {
@@ -415,16 +417,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xaxis= -2.5*np.log10(data['aper30_flux']/data['aper50_flux'])\n",
-    "yaxis= -2.5*np.log10(data['aper50_flux']/data['aper70_flux'])\n",
+    "#xaxis= -2.5*np.log10(data['aper30_flux']/data['aper50_flux'])\n",
+    "#yaxis= -2.5*np.log10(data['aper50_flux']/data['aper70_flux'])\n",
     "\n",
-    "xaxis2=data['CI_30_50']\n",
-    "yaxis2=data['CI_50_70']\n",
+    "#xaxis2=data['CI_30_50']\n",
+    "#yaxis2=data['CI_50_70']\n",
+    "\n",
+    "xaxis= -2.5*np.log10(data['aper50_flux']/data['aper30_flux'])\n",
+    "yaxis= -2.5*np.log10(data['aper70_flux']/data['aper50_flux'])\n",
+    "xaxis2=data['CI_50_30']\n",
+    "yaxis2=data['CI_70_50']\n",
     "\n",
     "plt.figure(figsize=(20,10))\n",
     "\n",
-    "plt.xlabel('CI_30_50',fontsize=24)\n",
-    "plt.ylabel('CI_50_70',fontsize=24)\n",
+    "#plt.xlabel('CI_30_50',fontsize=24)\n",
+    "#plt.ylabel('CI_50_70',fontsize=24)\n",
+    "\n",
+    "plt.xlabel('CI_50_30',fontsize=24)\n",
+    "plt.ylabel('CI_70_50',fontsize=24)\n",
+    "\n",
     "\n",
     "plt.plot(xaxis,yaxis, marker='o',linestyle='',markersize=10, color='blue') #ylim=(30000,40000))\n",
     "plt.plot(xaxis2,yaxis2, marker='x',linestyle='',markersize=10,color='yellow')\n",
@@ -467,7 +478,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Column names of output source catalog changed in Build 7.8, updating the notebook to match new names.