### PR TITLE
removing stdatamodel version num

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
     - requests>=2.22
     - scipy>=1.1.0
     - spherical-geometry>=1.2.18
-    - stdatamodels>=0.2.0,<1.0
+    - stdatamodels #>=0.2.0,<1.0
     - stsci.image>=2.3.3
     - tweakwcs>=0.7.0
     - matplotlib
@@ -78,4 +78,3 @@ variables:
 #  CRDS_PATH: "crds_cache"
   CRDS_PATH: "/grp/crds/cache"
   WIT4_PATH: "/grp/jwst/wit4"
-


### PR DESCRIPTION
Trying to get around a test failure by removing the version number from the stdatamodel call.