### PR TITLE
fixed issue with MIRI-specific import and updated nptt version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -59,7 +59,7 @@ dependencies:
     # These packages are imported from github because they are not available on pip
     - git+https://github.com/STScI-MIRI/miricoord
     - git+https://github.com/STScI-MIRI/miri3d
-    - git+https://github.com/spacetelescope/nirspec_pipe_testing_tool@1.1.24
+    - git+https://github.com/spacetelescope/nirspec_pipe_testing_tool@2.0.0
 
     # This repository has a specified version because the goal of this project is to test
     # a specified version of the pipeline, and produce output webpages.


### PR DESCRIPTION
- fixed old import for MIRI and commented out since it is not relevant for NIRSpec data
- changed version tag number to 2.0.0 to mark flight version