### PR TITLE
Fix NIRCam coron3 pipeline crash

### DIFF
--- a/jwst_validation_notebooks/calwebb_coron3/jwst_calcoron3_nircam_test.ipynb
+++ b/jwst_validation_notebooks/calwebb_coron3/jwst_calcoron3_nircam_test.ipynb
@@ -206,7 +206,7 @@
     "files = ['lib_ss20_sgd1_calints.fits', 'lib_ss20_sgd2_calints.fits', 'lib_ss20_sgd3_calints.fits',\n",
     "         'lib_ss20_sgd4_calints.fits', 'lib_ss20_sgd5_calints.fits', 'lib_ss20_sgd6_calints.fits',\n",
     "         'lib_ss20_sgd7_calints.fits', 'lib_ss20_sgd8_calints.fits', 'lib_ss20_sgd9_calints.fits',\n",
-    "         'lib_ss20_target_roll1_calints.fits', 'coro_test.asn']\n",
+    "         'lib_ss20_target_roll1_calints.fits', 'coro_test.json']\n",
     "for f in files:\n",
     "    file = get_bigdata('jwst_validation_notebooks',\n",
     "                       'validation_data',\n",
@@ -240,7 +240,7 @@
     "m.save_results = True\n",
     "\n",
     "# Run the pipeline\n",
-    "m.run('coro_test.asn')"
+    "m.run('coro_test.json')"
    ]
   },
   {
@@ -429,7 +429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR changes the association calls from asn to json to avoid coron3 pipeline crashes in the lastest pipeline build.