### PR TITLE
nptt tag update

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -60,7 +60,7 @@ dependencies:
     # These packages are imported from github because they are not available on pip
     - git+https://github.com/STScI-MIRI/miricoord
     - git+https://github.com/STScI-MIRI/miri3d
-    - git+https://github.com/spacetelescope/nirspec_pipe_testing_tool@2.0.0
+    - git+https://github.com/spacetelescope/nirspec_pipe_testing_tool@3.0.1
 
     # This repository has a specified version because the goal of this project is to test
     # a specified version of the pipeline, and produce output webpages.


### PR DESCRIPTION
New NPTT tag (3.0.1) fixes some bugs found and also changed barshadow code to use CRDS reference files rather than ESA format.